### PR TITLE
Add new endpoint for Election constants

### DIFF
--- a/app/api/v1/endpoints/election.py
+++ b/app/api/v1/endpoints/election.py
@@ -1,7 +1,8 @@
-from electionguard.election import ElectionDescription
+from electionguard.election import ElectionDescription, ElectionConstants
 from fastapi import APIRouter, HTTPException
 from os.path import realpath, join
 from typing import Any
+from app.utils.serialize import write_json_object
 
 
 router = APIRouter()
@@ -9,6 +10,15 @@ router = APIRouter()
 DATA_FOLDER_PATH = realpath(join(__file__, "../../../../data"))
 DESCRIPTION_FILE = join(DATA_FOLDER_PATH, "election_description.json")
 READ = "r"
+
+
+@router.get("/constants")
+def get_election_constants() -> Any:
+    """
+    Return the constants defined for an election
+    """
+    constants = ElectionConstants()
+    return write_json_object(constants)
 
 
 @router.get("/description")

--- a/tests/ElectionGuard Web Api.postman_collection.json
+++ b/tests/ElectionGuard Web Api.postman_collection.json
@@ -117,6 +117,26 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Get Election Constants",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/{{version}}/election/constants",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"{{version}}",
+								"election",
+								"constants"
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"protocolProfileBehavior": {}


### PR DESCRIPTION
### Issue

Fixes #51 

### Description
Outputs the default election constants in a new `GET /election/constants` endpoint.

### Testing
This includes an update to the postman collection to add the new endpoint.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💔Thank you!