### PR TITLE
🔓 Ballot decryption endpoints for all guardians

### DIFF
--- a/app/api/v1/guardian/ballot.py
+++ b/app/api/v1/guardian/ballot.py
@@ -1,0 +1,41 @@
+from electionguard.ballot import CiphertextAcceptedBallot
+from electionguard.decryption import compute_decryption_share_for_ballot
+from electionguard.election import CiphertextElectionContext
+from electionguard.scheduler import Scheduler
+from electionguard.serializable import write_json_object
+from fastapi import APIRouter, Body
+from typing import Any
+
+from ..models import (
+    convert_guardian,
+    DecryptBallotSharesRequest,
+    DecryptBallotSharesResponse,
+)
+from ..tags import TALLY
+
+router = APIRouter()
+
+
+@router.post("/decrypt-share", tags=[TALLY])
+def decrypt_ballot_shares(request: DecryptBallotSharesRequest = Body(...)) -> Any:
+    """
+    Decrypt this guardian's share of one or more ballots
+    """
+    ballots = [
+        CiphertextAcceptedBallot.from_json_object(ballot)
+        for ballot in request.encrypted_ballots
+    ]
+    context = CiphertextElectionContext.from_json_object(request.context)
+    guardian = convert_guardian(request.guardian)
+
+    scheduler = Scheduler()
+    shares = [
+        compute_decryption_share_for_ballot(guardian, ballot, context, scheduler)
+        for ballot in ballots
+    ]
+
+    response = DecryptBallotSharesResponse(
+        shares=[write_json_object(share) for share in shares]
+    )
+
+    return response

--- a/app/api/v1/guardian/ballot.py
+++ b/app/api/v1/guardian/ballot.py
@@ -1,10 +1,10 @@
+from typing import Any
 from electionguard.ballot import CiphertextAcceptedBallot
 from electionguard.decryption import compute_decryption_share_for_ballot
 from electionguard.election import CiphertextElectionContext
 from electionguard.scheduler import Scheduler
 from electionguard.serializable import write_json_object
 from fastapi import APIRouter, Body
-from typing import Any
 
 from ..models import (
     convert_guardian,

--- a/app/api/v1/guardian/ballot.py
+++ b/app/api/v1/guardian/ballot.py
@@ -16,7 +16,7 @@ from ..tags import TALLY
 router = APIRouter()
 
 
-@router.post("/decrypt-share", tags=[TALLY])
+@router.post("/decrypt-shares", tags=[TALLY])
 def decrypt_ballot_shares(request: DecryptBallotSharesRequest = Body(...)) -> Any:
     """
     Decrypt this guardian's share of one or more ballots

--- a/app/api/v1/guardian/routes.py
+++ b/app/api/v1/guardian/routes.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+from . import ballot
 from . import guardian
 from . import key
 from . import tally
@@ -7,4 +8,5 @@ router = APIRouter()
 
 router.include_router(guardian.router, prefix="/guardian")
 router.include_router(key.router, prefix="/key")
+router.include_router(ballot.router, prefix="/ballot")
 router.include_router(tally.router, prefix="/tally")

--- a/app/api/v1/mediator/ballot.py
+++ b/app/api/v1/mediator/ballot.py
@@ -1,6 +1,12 @@
-from typing import Any, Optional
-from electionguard.ballot import CiphertextBallot, PlaintextBallot
+from typing import Any, Dict, List, Optional
+from electionguard.ballot import (
+    CiphertextAcceptedBallot,
+    CiphertextBallot,
+    PlaintextBallot,
+)
 from electionguard.ballot_box import accept_ballot, BallotBoxState
+from electionguard.decrypt_with_shares import decrypt_ballot
+from electionguard.decryption_share import BallotDecryptionShare
 from electionguard.ballot_store import BallotStore
 from electionguard.election import (
     CiphertextElectionContext,
@@ -13,8 +19,13 @@ from electionguard.serializable import read_json_object, write_json_object
 from electionguard.utils import get_optional
 from fastapi import APIRouter, Body, HTTPException
 
-from ..models import AcceptBallotRequest, EncryptBallotsRequest, EncryptBallotsResponse
-from ..tags import CAST_AND_SPOIL, ENCRYPT_BALLOTS
+from ..models import (
+    AcceptBallotRequest,
+    DecryptBallotsRequest,
+    EncryptBallotsRequest,
+    EncryptBallotsResponse,
+)
+from ..tags import CAST_AND_SPOIL, ENCRYPT_BALLOTS, TALLY
 
 router = APIRouter()
 
@@ -31,6 +42,38 @@ def cast_ballot(request: AcceptBallotRequest = Body(...)) -> Any:
             detail="Ballot failed to be cast",
         )
     return casted_ballot.to_json_object()
+
+
+@router.post("/decrypt", tags=[TALLY])
+def decrypt_ballots(request: DecryptBallotsRequest = Body(...)) -> Any:
+    ballots = [
+        CiphertextAcceptedBallot.from_json_object(ballot)
+        for ballot in request.encrypted_ballots
+    ]
+    context: CiphertextElectionContext = CiphertextElectionContext.from_json_object(
+        request.context
+    )
+
+    # Build a lookup for each ballot, containing the shares for decryption
+    all_shares: List[BallotDecryptionShare] = [
+        read_json_object(share, BallotDecryptionShare)
+        for shares in request.shares.values()
+        for share in shares
+    ]
+    shares_by_ballot: Dict[str, Dict[str, BallotDecryptionShare]] = {}
+    for share in all_shares:
+        ballot_shares = shares_by_ballot.setdefault(share.ballot_id, {})
+        ballot_shares[share.guardian_id] = share
+
+    extended_base_hash = context.crypto_extended_base_hash
+    decrypted_ballots = {
+        ballot.object_id: decrypt_ballot(
+            ballot, shares_by_ballot[ballot.object_id], extended_base_hash
+        )
+        for ballot in ballots
+    }
+
+    return write_json_object(decrypted_ballots)
 
 
 @router.post("/spoil", tags=[CAST_AND_SPOIL])

--- a/app/api/v1/mediator/tally.py
+++ b/app/api/v1/mediator/tally.py
@@ -70,6 +70,11 @@ def decrypt_tally(request: DecryptTallyRequest = Body(...)) -> Any:
     }
 
     full_plaintext_tally = decrypt(tally, shares, context)
+    if not full_plaintext_tally:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to decrypt tally",
+        )
     published_plaintext_tally = publish_plaintext_tally(full_plaintext_tally)
 
     return published_plaintext_tally.to_json_object()
@@ -97,7 +102,7 @@ def _parse_tally_request(
 
 def _tally_ballots(
     tally: CiphertextTally, ballots: List[CiphertextAcceptedBallot]
-) -> PublishedCiphertextTally:
+) -> Any:
     """
     Append a series of ballots to a new or existing tally
     """

--- a/app/api/v1/mediator/tally.py
+++ b/app/api/v1/mediator/tally.py
@@ -12,7 +12,6 @@ from electionguard.tally import (
     publish_ciphertext_tally,
     publish_plaintext_tally,
     CiphertextTally,
-    PublishedCiphertextTally,
 )
 from fastapi import APIRouter, Body, HTTPException
 

--- a/app/api/v1/models/ballot.py
+++ b/app/api/v1/models/ballot.py
@@ -1,18 +1,23 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from .base import Base
 from .election import ElectionDescription, CiphertextElectionContext
+from .guardian import Guardian, GuardianId
 
 
 __all__ = [
+    "AcceptBallotRequest",
     "CiphertextAcceptedBallot",
     "CiphertextBallot",
-    "PlaintextBallot",
-    "AcceptBallotRequest",
+    "DecryptBallotSharesRequest",
+    "DecryptBallotSharesResponse",
+    "DecryptBallotsRequest",
     "EncryptBallotsRequest",
     "EncryptBallotsResponse",
+    "PlaintextBallot",
 ]
 
+BallotDecryptionShare = Any
 CiphertextAcceptedBallot = Any
 CiphertextBallot = Any
 PlaintextBallot = Any
@@ -22,6 +27,22 @@ class AcceptBallotRequest(Base):
     ballot: CiphertextBallot
     description: ElectionDescription
     context: CiphertextElectionContext
+
+
+class DecryptBallotsRequest(Base):
+    encrypted_ballots: List[CiphertextAcceptedBallot]
+    shares: Dict[GuardianId, List[BallotDecryptionShare]]
+    context: CiphertextElectionContext
+
+
+class DecryptBallotSharesRequest(Base):
+    encrypted_ballots: List[CiphertextAcceptedBallot]
+    guardian: Guardian
+    context: CiphertextElectionContext
+
+
+class DecryptBallotSharesResponse(Base):
+    shares: List[BallotDecryptionShare]
 
 
 class EncryptBallotsRequest(Base):


### PR DESCRIPTION
### Issue
Fixes #70 

### Description

#### **NEW** guardian endpoint for decrypting a guardian's share of one or more ballots
POST `/api/v1/ballot/decrypt-shares`

Request
```jsonc
{
  "encrypted_ballots": [/*one or more accepted ballots*/],
  "guardian": {/*private guardian representation*/},
  "context": {/*standard context object*/}
}
```

Response
```jsonc
{
  "shares": [/*ballot decryption shares...*/]
}
```

#### **NEW** mediator endpoint for decrypting one or more ballots from shares
POST `/api/v1/ballot/decrypt`

Request
```jsonc
{
  "encrypted_ballots": [/*one or more accepted ballots*/],
  "shares": {
    "<guardian id>": [/*ballot decryption shares*/]
  },
  "context": {/*standard context object*/}
}
```

Response
```jsonc
{
  "<ballot_id>": {/*dictionary of decrypted contests*/}
}
```

### Testing
Requests/tests have been added to Postman

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💙 Thank you!