### PR TITLE
✨ New Election context endpoint, remove description endpoint

### DIFF
--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -1,7 +1,19 @@
 from typing import Any
+from .base import Base
 
-__all__ = ["ElectionDescription", "CiphertextElectionContext"]
+__all__ = ["CiphertextElectionContext", "ElectionContextRequest", "ElectionDescription"]
 
 ElectionDescription = Any
 
 CiphertextElectionContext = Any
+
+
+class ElectionContextRequest(Base):
+    """
+    A request to build an Election Context for a given election
+    """
+
+    description: ElectionDescription
+    elgamal_public_key: str
+    number_of_guardians: int
+    quorum: int


### PR DESCRIPTION
### Issue
Closes #100 
Closes #97 

### Description

🔥 Removes the `/api/v1/election/description` endpoint

✨  **New** mediator endpoint:
`POST /api/v1/election/context`

Request
```jsonc
{
  "description": {/* standard election description */},
  "elgamal_public_key": "<result of combining public keys>",
  "number_of_guardians": 5,
  "quorum": 3
}
```

Response
```jsonc
{
    "crypto_base_hash": "<base hash>",
    "crypto_extended_base_hash": "<extended base hash>",
    "description_hash": "<description hash>",
    "elgamal_public_key": "<public key from the request>",
    "number_of_guardians": 5,
    "quorum": 3
}
```

### Testing
Added a test to Postman

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💙 Thank you!