### PR TITLE
Prevent automatic shutdown in Docker/Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM python:3.8 AS base
-ENV host 0.0.0.0
-ENV port 8000
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8 AS base
+ENV PORT 8000
 RUN apt update && apt-get install -y \
     libgmp-dev \
     libmpfr-dev \
@@ -10,14 +9,12 @@ COPY ./pyproject.toml /tmp/
 COPY ./poetry.lock /tmp/
 RUN cd /tmp && poetry export -f requirements.txt > requirements.txt
 RUN pip install -r /tmp/requirements.txt
+EXPOSE $PORT
 
 FROM base AS dev
-VOLUME [ "/app" ]
-EXPOSE $port
-CMD uvicorn app.main:app --reload --host "$host" --port "$port"
+VOLUME [ "/app/app" ]
+CMD /start-reload.sh
 
 FROM base AS prod
-COPY ./app /app
-EXPOSE $port
-# TODO: We should not have to use the --reload flag here! See issue #80
-CMD uvicorn app.main:app --reload --host "$host" --port "$port"
+COPY ./app /app/app
+# The base image will start gunicorn

--- a/app/api/v1/guardian/ballot.py
+++ b/app/api/v1/guardian/ballot.py
@@ -4,8 +4,9 @@ from electionguard.decryption import compute_decryption_share_for_ballot
 from electionguard.election import CiphertextElectionContext
 from electionguard.scheduler import Scheduler
 from electionguard.serializable import write_json_object
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, Depends
 
+from app.core.scheduler import get_scheduler
 from ..models import (
     convert_guardian,
     DecryptBallotSharesRequest,
@@ -17,7 +18,10 @@ router = APIRouter()
 
 
 @router.post("/decrypt-shares", tags=[TALLY])
-def decrypt_ballot_shares(request: DecryptBallotSharesRequest = Body(...)) -> Any:
+def decrypt_ballot_shares(
+    request: DecryptBallotSharesRequest = Body(...),
+    scheduler: Scheduler = Depends(get_scheduler),
+) -> Any:
     """
     Decrypt this guardian's share of one or more ballots
     """
@@ -28,7 +32,6 @@ def decrypt_ballot_shares(request: DecryptBallotSharesRequest = Body(...)) -> An
     context = CiphertextElectionContext.from_json_object(request.context)
     guardian = convert_guardian(request.guardian)
 
-    scheduler = Scheduler()
     shares = [
         compute_decryption_share_for_ballot(guardian, ballot, context, scheduler)
         for ballot in ballots

--- a/app/api/v1/guardian/tally.py
+++ b/app/api/v1/guardian/tally.py
@@ -5,10 +5,11 @@ from electionguard.election import (
     ElectionDescription,
     InternalElectionDescription,
 )
+from electionguard.scheduler import Scheduler
 from electionguard.serializable import write_json_object
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, Depends
 
-
+from app.core.scheduler import get_scheduler
 from ..models import (
     convert_guardian,
     convert_tally,
@@ -20,7 +21,10 @@ router = APIRouter()
 
 
 @router.post("/decrypt-share", tags=[TALLY])
-def decrypt_share(request: DecryptTallyShareRequest = Body(...)) -> Any:
+def decrypt_share(
+    request: DecryptTallyShareRequest = Body(...),
+    scheduler: Scheduler = Depends(get_scheduler),
+) -> Any:
     """
     Decrypt a single guardian's share of a tally
     """
@@ -31,6 +35,6 @@ def decrypt_share(request: DecryptTallyShareRequest = Body(...)) -> Any:
     guardian = convert_guardian(request.guardian)
     tally = convert_tally(request.encrypted_tally, description, context)
 
-    share = compute_decryption_share(guardian, tally, context)
+    share = compute_decryption_share(guardian, tally, context, scheduler)
 
     return write_json_object(share)

--- a/app/core/scheduler.py
+++ b/app/core/scheduler.py
@@ -1,0 +1,9 @@
+from electionguard.scheduler import Scheduler
+from functools import lru_cache
+
+__all__ = ["get_scheduler"]
+
+
+@lru_cache
+def get_scheduler() -> Scheduler:
+    return Scheduler()

--- a/app/core/scheduler.py
+++ b/app/core/scheduler.py
@@ -1,5 +1,5 @@
-from electionguard.scheduler import Scheduler
 from functools import lru_cache
+from electionguard.scheduler import Scheduler
 
 __all__ = ["get_scheduler"]
 

--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ app = get_app()
 
 
 @app.on_event("shutdown")
-def on_shutdown():
+def on_shutdown() -> None:
     # Ensure a clean shutdown of the singleton Scheduler
     scheduler = get_scheduler()
     scheduler.close()

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from app.api.v1.routes import get_routes
 from app.core.config import Settings
+from app.core.scheduler import get_scheduler
 
 logger = getLogger(__name__)
 
@@ -36,6 +37,14 @@ def get_app(settings: Optional[Settings] = None) -> FastAPI:
 
 
 app = get_app()
+
+
+@app.on_event("shutdown")
+def on_shutdown():
+    # Ensure a clean shutdown of the singleton Scheduler
+    scheduler = get_scheduler()
+    scheduler.close()
+
 
 if __name__ == "__main__":
     # IMPORTANT: This should only be used to debug the application.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,23 +9,23 @@ services:
       context: .
       target: dev
     volumes:
-      - "./app:/app"
+      - "./app:/app/app"
     ports:
       - 8000:8000
     environment:
       API_MODE: "mediator"
       PROJECT_NAME: "ElectionGuard Mediator API"
-      port: 8000
+      PORT: 8000
 
   guardian:
     build:
       context: .
       target: dev
     volumes:
-      - "./app:/app"
+      - "./app:/app/app"
     ports:
       - 8001:8001
     environment:
       API_MODE: "guardian"
       PROJECT_NAME: "ElectionGuard Guardian API"
-      port: 8001
+      PORT: 8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       API_MODE: "mediator"
       PROJECT_NAME: "ElectionGuard Mediator API"
-      port: 8000
+      PORT: 8000
 
   guardian:
     build:
@@ -20,4 +20,4 @@ services:
     environment:
       API_MODE: "guardian"
       PROJECT_NAME: "ElectionGuard Guardian API"
-      port: 8001
+      PORT: 8001

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,10 @@
+from typing import Generator
 import pytest
 from app.core.scheduler import get_scheduler
 
 
 @pytest.yield_fixture(scope="session", autouse=True)
-def scheduler_lifespan():
+def scheduler_lifespan() -> Generator[None, None, None]:
     """
     Ensure that the global scheduler singleton is
     torn down when tests finish.  Otherwise, the test runner will hang

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from app.core.scheduler import get_scheduler
+
+
+@pytest.yield_fixture(scope="session", autouse=True)
+def scheduler_lifespan():
+    """
+    Ensure that the global scheduler singleton is
+    torn down when tests finish.  Otherwise, the test runner will hang
+    waiting for the scheduler to complete.
+    """
+    yield None
+    scheduler = get_scheduler()
+    scheduler.close()

--- a/tests/postman/docker-compose.yml
+++ b/tests/postman/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       API_MODE: "mediator"
       PROJECT_NAME: "ElectionGuard Mediator API"
-      port: 80
+      PORT: 80
 
   guardian:
     build:
@@ -29,7 +29,7 @@ services:
     environment:
       API_MODE: "guardian"
       PROJECT_NAME: "ElectionGuard Guardian API"
-      port: 80
+      PORT: 80
   
   test-runner:
     build:


### PR DESCRIPTION
### Issue
Fixes #80 

### Description
The scheduler is using python's multiprocessing capabilities, but the way its pool lifespan is managed when multiple instances are created produces issues on Linux (and therefore in Docker).  Namely - uvicorn is incorrectly detecting that the worker process is complete and shutting it down.

This PR:
- Scopes a single `Scheduler` as a singleton injectable dependency.
- Uses that singleton `Scheduler` in all python functions which accept one.
- Updates the Docker image to use the official gunicorn/uvicorn/FastAPI base, which is recommended for production.

### Testing
`make lint`, `make test-integration`, and `make-docker-postman-test` all pass.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💙 Thank you!